### PR TITLE
Fixes for tasks which can fail during the update operation

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -3,7 +3,7 @@ _tasks:
     # Removed until charm.py sets a status
     # - invoke migrate-test-charm
     - invoke check-yaml
-    - "chmod +x src/charm.py"
+    - invoke charm-permissions
     - invoke remove-unused-files
     - invoke remove-tasks
 _skip_if_exists:

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -37,17 +37,16 @@ def black(c):
 @task
 def check_yaml(c):
     """If the yaml files are empty, uncomment the default examples"""
-    config_file = Path("./config.yaml")
-    action_file = Path("./actions.yaml")
-    if config_file.exists() and action_file.exists():
-        config = yaml.safe_load(config_file.read_text())
-        actions = yaml.safe_load(action_file.read_text())
-        if not config and not actions:
-            with fileinput.input((action_file, config_file), inplace=1) as f:
-                for line in f:
-                    if ":" in line:
-                        line = line[1:]  # Remove the comment prefix
-                    print(line, end="")
+    for file_to_process in (Path("./config.yaml"), Path("./actions.yaml")):
+        if not file_to_process.exists():
+            continue
+        if yaml.safe_load(file_to_process.read_text()):
+            continue
+        with fileinput.input(file_to_process, inplace=1) as f:
+            for line in f:
+                if ":" in line:
+                    line = line[1:]  # Remove the comment prefix
+                print(line, end="")
 
 
 @task

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -1,4 +1,5 @@
 import fileinput
+import os
 import subprocess
 from pathlib import Path
 
@@ -36,16 +37,25 @@ def black(c):
 @task
 def check_yaml(c):
     """If the yaml files are empty, uncomment the default examples"""
-    config_file = Path("config.yaml")
-    config = yaml.safe_load(config_file.read_text())
-    action_file = Path("actions.yaml")
-    actions = yaml.safe_load(action_file.read_text())
-    if not config and not actions:
-        with fileinput.input((action_file, config_file), inplace=1) as f:
-            for line in f:
-                if ":" in line:
-                    line = line[1:]  # Remove the comment prefix
-                print(line, end="")
+    config_file = Path("./config.yaml")
+    action_file = Path("./actions.yaml")
+    if config_file.exists() and action_file.exists():
+        config = yaml.safe_load(config_file.read_text())
+        actions = yaml.safe_load(action_file.read_text())
+        if not config and not actions:
+            with fileinput.input((action_file, config_file), inplace=1) as f:
+                for line in f:
+                    if ":" in line:
+                        line = line[1:]  # Remove the comment prefix
+                    print(line, end="")
+
+
+@task
+def charm_permissions(c):
+    """Make sure charm.py is executable"""
+    charm = Path("src/charm.py")
+    if charm.exists():
+        os.chmod(charm, 0o755)
 
 
 @task

--- a/template/tox.ini
+++ b/template/tox.ini
@@ -22,8 +22,7 @@ deps =
     # Until 2.8.6 is released
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@loop
-    # pytest-operator 
+    pytest-operator 
 commands = pytest -v --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]


### PR DESCRIPTION
I was trying to use this for a new charm and found on repeat update commands task fail this seems to be because copier makes a temporary folder clones into that, and then compare to the final destination. The temporary clone still runs the actions, which fail b/c they can't find the expected files. This avoid the issue by exiting if their is no file to operate on.